### PR TITLE
fix: solve oversights in example project

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -3,3 +3,5 @@ node_modules
 /.cache
 /build
 /public/build
+
+vite.config.ts.*.mjs

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build",
-    "dev": "bun --watch ./server/index.ts",
+    "dev": "bun ./server/index.ts",
     "format": "prettier --ignore-path .gitignore --ignore-unknown --cache --cache-location node_modules/.cache/prettiercache --write .",
     "lint": "eslint --ignore-path .gitignore --no-error-on-unmatched-pattern --cache --cache-location node_modules/.cache/eslint --fix .",
     "start": "NODE_ENV=production bun ./server/index.ts"

--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { remix } from "../../src";
+import { remix } from "elysia-remix";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -10,7 +10,9 @@ new Elysia()
 		}),
 	)
 	.get("/some", "Hello")
-	.listen(port, console.log);
+	.listen(port, () => {
+		console.log(`Elysia Remix server is running at http://localhost:${port}`);
+	});
 
 declare module "@remix-run/server-runtime" {
 	interface AppLoadContext {


### PR DESCRIPTION
Closes #1 

I noticed you seem to be following the Conventional Commits specification, so I went ahead and wrote mine in accordance.

Changes:

- Fixed the relative import to this package in the example. This made it so it only worked if cloning the entire repository and not when using the quick start command in the `README.md` by itself.

- Removed the `--watch` flag when running the _dev_ server since the native Vite HMR already works with your package and having both it and the `--watch` flag causes an infinite hot reload loop.

- Added the timestamps generated by Vite when the _dev_ server is run to `.gitignore` as a bonus change, these are usually deleted immediately by Vite itself, but I find it is good pratice to ignore them since they can some times not be erased and pass through a commit unnoticed.